### PR TITLE
fix: fix error during clear operation

### DIFF
--- a/setcert.py
+++ b/setcert.py
@@ -227,7 +227,6 @@ def main():
             datetime.datetime.utcnow() + datetime.timedelta(days=3650)
         ).sign(key, hashes.SHA256())
 
-        operation = ldap3.MODIFY_REPLACE
         # Write our certificate out to disk.
         
         print_m(f'Saving certificate key to {certout}')
@@ -237,6 +236,8 @@ def main():
         # Use binary data for writing to object
         certdata = cert.public_bytes(serialization.Encoding.DER)
 
+    operation = ldap3.MODIFY_REPLACE
+    
     if args.clear:
         print_o('Printing object before clearing')
         print(targetobject)


### PR DESCRIPTION
There was an error with the clean operation:
```
$ python3 setcert.py -c -u 'CORP\user' -p 'pass'  -t 'WIN-DESKTOP$' ldap://1.1.1.1
[-] Connecting to host...
[-] Binding to host
[+] Bind OK
[+] Found modification target
[+] Printing object before clearing
[...]

Traceback (most recent call last):
  File "/opt/tools/roadtools_hybrid/setcert.py", line 259, in <module>
    main()
  File "/opt/tools/roadtools_hybrid/setcert.py", line 243, in main
    c.modify(targetobject.entry_dn, {'userCertificate':[(operation, [])]})
UnboundLocalError: local variable 'operation' referenced before assignment

```

This should be fixed with the PR :)