### PR TITLE
Added loadticketcloud.py to parse the tgt_cloud returned by roadtx prt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ python setcert.py 10.0.1.1 -t 'DESKTOP-NAME$' -u 'domain\DESKTOP-NAME$' -p compu
 
 This tool can extract a partial Kerberos TGT from a roadtx `.prt` file and save it in a ccache for use with tools such as impacket. Only useful if the `.tgt` file actually includes a TGT for on-prem.
 
+## loadticketcloud.py
+
+This tool can extract an Entra Kerberos TGT from a roadtx `.prt` file and save it in `tgt_cloud.ccache`. This TGT can be used to request TGS for accessing Azure file shares using Kerberos authentication.
+
 ## partialtofulltgt.py
 
 This tool takes a partial TGT from either a ccache (extracted using loadticket.py) or from a `.prt` file directly, and upgrades this to a full TGT. It will also recover the NT hash of this account via the KRB KEY LIST feature.

--- a/loadticketcloud.py
+++ b/loadticketcloud.py
@@ -1,0 +1,42 @@
+from pyasn1.codec.der import decoder, encoder
+from impacket.krb5.asn1 import AS_REP, EncASRepPart
+from impacket.krb5.crypto import Key, _enctype_table, InvalidChecksum
+from impacket.krb5.ccache import CCache
+import logging
+import binascii
+import json
+import codecs
+import base64
+
+with codecs.open('roadtx.prt','r', 'utf-8') as prtfile:
+	data = json.load(prtfile)
+ticketdata = json.loads(data['tgt_cloud'])
+ticketbin = base64.b64decode(ticketdata['messageBuffer'])
+try:
+    sessionkey = binascii.unhexlify(data['tgt_cloud_sessionkey'])
+except KeyError:
+    sessionkey = base64.b64decode(ticketdata['clientKey'])
+asRep = decoder.decode(ticketbin, asn1Spec=AS_REP())[0]
+# print(asRep)
+cipher = _enctype_table[18]
+key = Key(18, sessionkey)
+cipherText = asRep['enc-part']['cipher']
+tgt = ticketbin
+try:
+    plainText = cipher.decrypt(key, 3, cipherText)
+except InvalidChecksum as e:
+    # probably bad password if preauth is disabled
+    if preAuth is False:
+        error_msg = "failed to decrypt session key: %s" % str(e)
+        raise SessionKeyDecryptionError(error_msg, asRep, cipher, key, cipherText)
+    raise
+encASRepPart = decoder.decode(plainText, asn1Spec = EncASRepPart())[0]
+# print(encASRepPart)
+
+cipher = _enctype_table[encASRepPart['key']['keytype']]
+sessionKey = Key(cipher.enctype,encASRepPart['key']['keyvalue'].asOctets())
+
+ccache = CCache()
+ccache.fromTGT(tgt, key, sessionKey)
+ccache.saveFile('tgt_cloud.ccache')
+


### PR DESCRIPTION
The file tgt_cloud.ccache can be used to request TGS for accessing Azure file shares using Kerberos authentication.